### PR TITLE
Fixed Editor issues

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -171,7 +171,7 @@ if ( ! function_exists('inkblot_after_setup_theme')) :
 function inkblot_after_setup_theme() {
 	load_theme_textdomain('inkblot', get_template_directory() . '/_/l10n');
 	
-	add_editor_style(get_stylesheet_uri());
+	//add_editor_style(get_stylesheet_uri());
 	
 	if (get_theme_mod('font') or get_theme_mod('page_font') or get_theme_mod('title_font')) {
 		foreach (array_filter(array(
@@ -183,7 +183,7 @@ function inkblot_after_setup_theme() {
 		}
 	}
 	
-	add_editor_style(add_query_arg(array('inkblot-mods' => 'editor'), home_url('/')));
+	add_editor_style(add_query_arg(array('inkblot-mods' => 'editor')));
 	
 	add_filter('use_default_gallery_style', '__return_false');
 	add_filter('show_recent_comments_widget_style', '__return_false');

--- a/functions.php
+++ b/functions.php
@@ -183,7 +183,7 @@ function inkblot_after_setup_theme() {
 		}
 	}
 	
-	add_editor_style(add_query_arg(array('inkblot-mods' => 'editor')));
+	add_editor_style(add_query_arg(array('inkblot-mods' => 'editor'), admin_url()) );
 	
 	add_filter('use_default_gallery_style', '__return_false');
 	add_filter('show_recent_comments_widget_style', '__return_false');


### PR DESCRIPTION
- inkblot mods were not properly loaded when wp-admin is under SSL
- Adding full stylesheet in editor was preventing WP Editor to work

When using add_editor_style is better to load just a few styles instead of the full style.css as many things can go wrong in the editor (like this case)

I've also removed home_url('/') and replaced it for admin_url() when loading inkblot mods in the editor as it was throwing a mixed content error in JS console when wp-admin is under SSL. This will add the inkblot-mods under SSL if needed.

Thanks
